### PR TITLE
Reverted errors array check to check for length

### DIFF
--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -24,7 +24,7 @@ router.post(
   ],
   async (req, res) => {
     const errors = validationResult(req);
-    if (errors) {
+    if (errors.length > 0) {
       return res.status(400).json({ errors: errors.array() });
     }
 
@@ -76,7 +76,7 @@ router.post(
     async (req, res) => {
       const errors = validationResult(req);
 
-      if (errors) {
+      if (errors.length > 0) {
         return res.status(400).json({ errors: errors.array() });
       }
 


### PR DESCRIPTION
Empty errors array is not falsy, so it failed the check for errors and so sent a default 400 with the empty errors array. Updated to check if the errors array has length > 0