### PR TITLE
removed warnings from console related to invalid props and missing key

### DIFF
--- a/client/src/pages/Experience/Experience.js
+++ b/client/src/pages/Experience/Experience.js
@@ -103,25 +103,19 @@ const Experience = () => {
   }
   return (
     <ExperienceContainer>
-      <Grid container spacing={1} direction="column" alignItems="space-evenly">
+      <Grid container spacing={1} direction="column" justify="space-evenly">
         <Grid item xs={12}>
           <Typography className={classes.text}>
             Add your experience here
           </Typography>
         </Grid>
         <Grid item xs={12}>
-          <Grid
-            container
-            spacing={3}
-            direction="column"
-            alignItems="space-evenly"
-          >
+          <Grid container spacing={3} direction="column" justify="space-evenly">
             {experience.map((ele, idx) => {
               const currLanguage = Object.keys(experience[idx])[0];
               return (
-                <Grid item>
+                <Grid item key={currLanguage}>
                   <NewExperienceForm
-                    key={currLanguage}
                     updateExperience={updateExperience}
                     language={currLanguage}
                     level={ele[currLanguage]}

--- a/client/src/pages/Experience/NewExperienceForm.js
+++ b/client/src/pages/Experience/NewExperienceForm.js
@@ -43,7 +43,6 @@ const NewExperienceForm = ({
   useDeepCompareEffect(() => {
     // update experience at current index of experience section, with selected language as key
     // and level as property
-    console.log("ran effect");
     updateExperience(index, { [selected.language]: Number(selected.level) });
   }, [index, selected]);
 

--- a/client/src/pages/Experience/NewExperienceForm.js
+++ b/client/src/pages/Experience/NewExperienceForm.js
@@ -43,6 +43,7 @@ const NewExperienceForm = ({
   useDeepCompareEffect(() => {
     // update experience at current index of experience section, with selected language as key
     // and level as property
+    console.log("ran effect");
     updateExperience(index, { [selected.language]: Number(selected.level) });
   }, [index, selected]);
 


### PR DESCRIPTION
Removed warnings by moving key in map (Experience.js) to outer `<Grid>` component and using justify instead of alignItems prop in a couple of places.